### PR TITLE
bugfix:SublimeText3命令行启动可以输入中文,图标启动无法输入中文

### DIFF
--- a/sublime-imfix
+++ b/sublime-imfix
@@ -104,10 +104,10 @@ then
     then
     sudo rm /usr/bin/subl && sudo cp ./src/subl /usr/bin/
   fi
-  echo '**************** Replacing sublime-text.desktop with new one ****************'
-  if [ -e '/usr/share/applications/sublime-text.desktop' ]
+  echo '**************** Replacing sublime_text.desktop with new one ****************'
+  if [ -e '/usr/share/applications/sublime_text.desktop' ]
     then
-    sudo rm /usr/share/applications/sublime-text.desktop && sudo cp ./src/sublime-text.desktop /usr/share/applications/
+    sudo rm /usr/share/applications/sublime_text.desktop && sudo cp ./src/sublime-text.desktop /usr/share/applications/
     sudo chmod 644 /usr/share/applications/sublime-text.desktop
   fi
   echo '**************** Sublime Text input method problem fixed! ****'


### PR DESCRIPTION
sublime版本:sublime text3 3126
linux版本: Ubuntu16.04LTS x64
出现问题的步骤:
1. 安装3126版本的sublime
2. 执行sublime-imfix脚本修复输入法问题
期望结果:
从命令行和图标打开均可以使用中文输入
实际结果:
从命令行打开sublime,可以输入中文;从图标打开sublime,无法输入中文

问题原因:
sublime-imfix脚本中,替换`desktop`文件的流程如下:
判断/usr/share/applications下有没有叫做`sublime-text.desktop`的文件,如果有,则替换成本仓库src目录下的`sublime-text.desktop`.
可是,sublime
text3安装时,创建的desktop文件名字实际为`sublime_text.desktop`,因此导致desktop没有被替换.最终出现图标打开sublime无法输入中文的问题.