### PR TITLE
Add StartupWMClass to desktop file

### DIFF
--- a/src/sublime-text.desktop
+++ b/src/sublime-text.desktop
@@ -12,6 +12,7 @@ Icon=sublime-text
 Categories=TextEditor;Development;
 StartupNotify=true
 Actions=Window;Document;
+StartupWMClass=Sublime_text
 
 [Desktop Action Window]
 Name=New Window


### PR DESCRIPTION
Since Sublime Text is launched via subl command which is a helper shell script instead of the actual excutable of the program, some other management program cannot treat the `sublime_text` or `sublime-text` process as the program that `sublime-text.desktop` linked to. Thus in the taskbar (dock, etc.) will show another icon beside the pinned icon. Adding the `StartupWMClass` property will solve this problem.